### PR TITLE
release: 1.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,140 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+max_line_length = 120
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# TODO: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
+
+#### .NET Syntax Conventions ####
+
+dotnet_style_qualification_for_property = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_event = false
+
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true
+csharp_style_var_elsewhere = false
+
+csharp_prefer_braces = false
+csharp_style_throw_expression = false
+dotnet_style_object_initializer = true
+csharp_style_inlined_variable_declaration = true
+
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+
+csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_methods = when_on_single_line
+csharp_style_expression_bodied_operators = when_on_single_line
+csharp_style_expression_bodied_properties = when_on_single_line
+csharp_style_expression_bodied_indexers = when_on_single_line
+csharp_style_expression_bodied_accessors = when_on_single_line
+
+dotnet_style_collection_initializer = true
+dotnet_style_coalesce_expression = true
+
+dotnet_style_null_propagation = true
+dotnet_style_prefer_auto_properties = true
+dotnet_style_explicit_tuple_names = true
+csharp_prefer_simple_default_expression = true
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+
+csharp_style_prefer_local_over_anonymous_function = true
+dotnet_style_require_accessibility_modifiers = always
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+csharp_style_deconstructed_variable_declaration = true
+dotnet_style_readonly_field = true
+
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+csharp_style_expression_bodied_lambdas = when_on_single_line
+dotnet_style_prefer_compound_assignment = true
+
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+dotnet_style_namespace_match_folder = true
+
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = none
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+csharp_using_directive_placement = outside_namespace
+
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_range_operator = true
+
+dotnet_code_quality_unused_parameters = all
+csharp_style_expression_bodied_local_functions = when_on_single_line
+csharp_prefer_static_local_function = true
+csharp_prefer_simple_using_statement = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+csharp_style_prefer_pattern_matching = true
+dotnet_remove_unnecessary_suppression_exclusions = all
+csharp_style_prefer_not_pattern = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_namespace_declarations = file_scoped
+csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_tuple_swap = true
+csharp_style_conditional_delegate_call = true

--- a/.github/workflows/ci-build-project.yml
+++ b/.github/workflows/ci-build-project.yml
@@ -1,0 +1,17 @@
+name: 'Build .NET Solution'
+on: pull_request
+jobs:
+  build:
+    name: 'Build Solution'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+        # dotnet version is sourced from global.json
+      - name: 'Setup dotNET'
+        id: install_dotnet
+        uses: actions/setup-dotnet@v1
+
+      - name: 'Build Solution using .NET CLI'
+        id: build_solution
+        run: 'dotnet build ./TTools.StatusPageIO.Api.sln'

--- a/.github/workflows/publish-nuget-net6.yml
+++ b/.github/workflows/publish-nuget-net6.yml
@@ -1,0 +1,32 @@
+name: Publish library to NuGet
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - src/TTools.StatusPageIO.Api/**
+
+jobs:
+  publish_net6:
+    name: Publish Library to NuGet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 'Setup dotNET'
+        id: install_dotnet
+        uses: actions/setup-dotnet@v1
+
+      - name: 'Publish NuGet Package'
+        id: publish_nuget
+        uses: alirezanet/publish-nuget@v3.0.0
+        with:
+          PROJECT_FILE_PATH: 'src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj'
+          PACKAGE_NAME: 'TTools.StatusPageIO.Api'
+          TAG_COMMIT: true
+          TAG_FORMAT: 'v*'
+          NUGET_KEY: '${{secrets.NUGET_API_KEY}}'
+          NUGET_SOURCE: 'https://api.nuget.org'
+          INCLUDE_SYMBOLS: true

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 TTools
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # StatusPageIO.Api
+
+## License
+
+This project is licensed under the MIT license. See [LICENSE.txt](./LICENSE.txt) for more information.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# StatusPageIO.Api

--- a/README.md
+++ b/README.md
@@ -1,5 +1,39 @@
 # StatusPageIO.Api
 
+This project aims to provide a wrapper around the public JSON file-based StatusPage.io 'API'.
+
+## Usage
+
+The status page client can be initialised in two main ways:
+
+### Self-instantiation
+```csharp
+// Construct it yourself, but make sure to dispose of it with 'using'!
+using var statusPageClient = new StatusPageIoClient();
+```
+
+## Microsoft.Extensions.DependencyInjection extensions
+```csharp 
+// ... your usual WebApplicationBuilder setup in Program.cs
+
+// Basic setup with the StatusPageIoClientConfiguration class
+builder.Services.AddStatusPageHttpClient(
+    (serviceProvider, config) => {
+        // The base URL of your status page. You could pull this from IConfiguration via the provided IServiceProvider parameter
+        config.StatusPageBaseUri = new Uri("https://www.githubstatus.com");
+    });
+
+// OR if you need more control over the HttpClient, you can directly configure it
+builder.Services.AddStatusPageHttpClient(
+    (serviceProvider, httpClient) => {
+        // The base URL of your status page. You could pull this from IConfiguration via the provided IServiceProvider parameter
+        httpClient.BaseAddress = new Uri("https://www.githubstatus.com");
+        httpClient.Timeout = TimeSpan.FromSeconds(10);
+    });
+    
+// ... the rest of the owl
+```
+
 ## License
 
 This project is licensed under the MIT license. See [LICENSE.txt](./LICENSE.txt) for more information.

--- a/TTools.StatusPageIO.Api.sln
+++ b/TTools.StatusPageIO.Api.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TTools.StatusPageIO.Api", "src\TTools.StatusPageIO.Api\TTools.StatusPageIO.Api.csproj", "{9DFED654-CCE4-40B2-A144-65AB386DFCF1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F0426126-88F1-4691-9CC8-C1DE653EC69C}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+		global.json = global.json
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9DFED654-CCE4-40B2-A144-65AB386DFCF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DFED654-CCE4-40B2-A144-65AB386DFCF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DFED654-CCE4-40B2-A144-65AB386DFCF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DFED654-CCE4-40B2-A144-65AB386DFCF1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}

--- a/src/TTools.StatusPageIO.Api/Extensions/StatusPageServiceCollectionExtensions.cs
+++ b/src/TTools.StatusPageIO.Api/Extensions/StatusPageServiceCollectionExtensions.cs
@@ -24,8 +24,7 @@ public static class StatusPageServiceCollectionExtensions
             (serviceProvider, httpClient) =>
             {
                 var configuration = new StatusPageIoClientConfiguration();
-                if (configureAction is not null)
-                    configureAction(serviceProvider, configuration);
+                configureAction?.Invoke(serviceProvider, configuration);
 
                 SetupHttpClient(httpClient);
                 httpClient.BaseAddress = configuration.StatusPageBaseUri;

--- a/src/TTools.StatusPageIO.Api/Extensions/StatusPageServiceCollectionExtensions.cs
+++ b/src/TTools.StatusPageIO.Api/Extensions/StatusPageServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace TTools.StatusPageIO.Api.Extensions;
@@ -14,6 +15,7 @@ public static class StatusPageServiceCollectionExtensions
     /// <param name="serviceCollection">The service collection to register the client against</param>
     /// <param name="configureAction">The action to configure the status page HttpClient</param>
     /// <returns>The HttpClient's builder</returns>
+    [PublicAPI]
     public static IHttpClientBuilder AddStatusPageHttpClient(this IServiceCollection serviceCollection,
         Action<IServiceProvider, StatusPageIoClientConfiguration>? configureAction)
     {
@@ -35,6 +37,7 @@ public static class StatusPageServiceCollectionExtensions
     /// <param name="serviceCollection">The service collection to register the client against</param>
     /// <param name="configureAction">The action to configure the status page HttpClient</param>
     /// <returns>The HttpClient's builder</returns>
+    [PublicAPI]
     public static IHttpClientBuilder AddStatusPageHttpClient(this IServiceCollection serviceCollection,
         Action<IServiceProvider, HttpClient> configureAction)
     {

--- a/src/TTools.StatusPageIO.Api/Extensions/StatusPageServiceCollectionExtensions.cs
+++ b/src/TTools.StatusPageIO.Api/Extensions/StatusPageServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+using System.Net.Http.Headers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TTools.StatusPageIO.Api.Extensions;
+
+/// <summary>
+/// Extensions for registering the IStatusPageIoClient with a ServiceProvider
+/// </summary>
+public static class StatusPageServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds a scoped service to interact with a site's public StatusPage.IO API
+    /// </summary>
+    /// <param name="serviceCollection">The service collection to register the client against</param>
+    /// <param name="configureAction">The action to configure the status page HttpClient</param>
+    /// <returns>The HttpClient's builder</returns>
+    public static IHttpClientBuilder AddStatusPageHttpClient(this IServiceCollection serviceCollection,
+        Action<IServiceProvider, StatusPageIoClientConfiguration>? configureAction)
+    {
+        return serviceCollection.AddHttpClient<IStatusPageIoClient, StatusPageIoClient>(
+            (serviceProvider, httpClient) =>
+            {
+                var configuration = new StatusPageIoClientConfiguration();
+                if (configureAction is not null)
+                    configureAction(serviceProvider, configuration);
+
+                SetupHttpClient(httpClient);
+                httpClient.BaseAddress = configuration.StatusPageBaseUri;
+            });
+    }
+
+    /// <summary>
+    /// Adds a scoped service to interact with a site's public StatusPage.IO API
+    /// </summary>
+    /// <param name="serviceCollection">The service collection to register the client against</param>
+    /// <param name="configureAction">The action to configure the status page HttpClient</param>
+    /// <returns>The HttpClient's builder</returns>
+    public static IHttpClientBuilder AddStatusPageHttpClient(this IServiceCollection serviceCollection,
+        Action<IServiceProvider, HttpClient> configureAction)
+    {
+        return serviceCollection.AddHttpClient<IStatusPageIoClient, StatusPageIoClient>(
+            (serviceProvider, httpClient) =>
+            {
+                SetupHttpClient(httpClient);
+                configureAction(serviceProvider, httpClient);
+            });
+    }
+
+    // TODO: support service-scoped IStatusPageIoClient registrations (ugly?)
+
+    private static void SetupHttpClient(HttpClient httpClient)
+    {
+        httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    }
+}

--- a/src/TTools.StatusPageIO.Api/Extensions/StatusPageServiceCollectionExtensions.cs
+++ b/src/TTools.StatusPageIO.Api/Extensions/StatusPageServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +16,7 @@ public static class StatusPageServiceCollectionExtensions
     /// <param name="serviceCollection">The service collection to register the client against</param>
     /// <param name="configureAction">The action to configure the status page HttpClient</param>
     /// <returns>The HttpClient's builder</returns>
-    [PublicAPI]
+    [PublicAPI, SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IHttpClientBuilder AddStatusPageHttpClient(this IServiceCollection serviceCollection,
         Action<IServiceProvider, StatusPageIoClientConfiguration>? configureAction)
     {
@@ -37,7 +38,7 @@ public static class StatusPageServiceCollectionExtensions
     /// <param name="serviceCollection">The service collection to register the client against</param>
     /// <param name="configureAction">The action to configure the status page HttpClient</param>
     /// <returns>The HttpClient's builder</returns>
-    [PublicAPI]
+    [PublicAPI, SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IHttpClientBuilder AddStatusPageHttpClient(this IServiceCollection serviceCollection,
         Action<IServiceProvider, HttpClient> configureAction)
     {

--- a/src/TTools.StatusPageIO.Api/GlobalUsings.cs
+++ b/src/TTools.StatusPageIO.Api/GlobalUsings.cs
@@ -1,0 +1,3 @@
+// Global using directives
+
+global using System.Text.Json.Serialization;

--- a/src/TTools.StatusPageIO.Api/IStatusPageIoClient.cs
+++ b/src/TTools.StatusPageIO.Api/IStatusPageIoClient.cs
@@ -1,0 +1,79 @@
+using TTools.StatusPageIO.Api.Models;
+using TTools.StatusPageIO.Api.Models.Response;
+
+namespace TTools.StatusPageIO.Api;
+
+public interface IStatusPageIoClient : IDisposable
+{
+    #region Summary
+
+    /// <summary>
+    /// Gets the status page's summary for a site
+    /// </summary>
+    /// <param name="cancellationToken">A CancellationToken to stop the request</param>
+    /// <returns>TODO</returns>
+    Task<SummaryResponse?> GetSummaryAsync(CancellationToken cancellationToken);
+
+    #endregion
+
+    #region Status
+
+    /// <summary>
+    /// Gets the rollup of the site's current status
+    /// </summary>
+    /// <param name="cancellationToken">A CancellationToken to stop the request</param>
+    /// <returns>TODO</returns>
+    Task<StatusResponse?> GetStatusAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists the components of a site with their respective status
+    /// </summary>
+    /// <param name="cancellationToken">A CancellationToken to stop the request</param>
+    /// <returns>TODO</returns>
+    Task<ComponentsResponse?> GetComponentsAsync(CancellationToken cancellationToken);
+
+    #endregion
+
+    #region Incidents
+
+    /// <summary>
+    /// Lists unresolved incidents of a site
+    /// </summary>
+    /// <param name="cancellationToken">A CancellationToken to stop the request</param>
+    /// <returns>TODO</returns>
+    Task<IncidentsResponse?> GetUnresolvedIncidentsAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists all past incidents of a site (max. 50)
+    /// </summary>
+    /// <param name="cancellationToken">A CancellationToken to stop the request</param>
+    /// <returns>TODO</returns>
+    Task<IncidentsResponse?> GetAllIncidentsAsync(CancellationToken cancellationToken);
+
+    #endregion
+
+    #region Maintenance
+
+    /// <summary>
+    /// Gets upcoming maintenance windows for a site
+    /// </summary>
+    /// <param name="cancellationToken">A CancellationToken to stop the request</param>
+    /// <returns>TODO</returns>
+    Task<ScheduledMaintenancesResponse?> GetUpcomingMaintenanceAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets currently active maintenance for a site
+    /// </summary>
+    /// <param name="cancellationToken">A CancellationToken to stop the request</param>
+    /// <returns>TODO</returns>
+    Task<ScheduledMaintenancesResponse?> GetActiveMaintenanceAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets upcoming maintenance windows for the site
+    /// </summary>
+    /// <param name="cancellationToken">A CancellationToken to stop the request</param>
+    /// <returns>TODO</returns>
+    Task<ScheduledMaintenancesResponse?> GetAllMaintenanceAsync(CancellationToken cancellationToken);
+
+    #endregion
+}

--- a/src/TTools.StatusPageIO.Api/IStatusPageIoClient.cs
+++ b/src/TTools.StatusPageIO.Api/IStatusPageIoClient.cs
@@ -3,7 +3,7 @@ using TTools.StatusPageIO.Api.Models.Response;
 
 namespace TTools.StatusPageIO.Api;
 
-public interface IStatusPageIoClient
+public interface IStatusPageIoClient : IDisposable
 {
     #region Summary
 

--- a/src/TTools.StatusPageIO.Api/IStatusPageIoClient.cs
+++ b/src/TTools.StatusPageIO.Api/IStatusPageIoClient.cs
@@ -3,7 +3,7 @@ using TTools.StatusPageIO.Api.Models.Response;
 
 namespace TTools.StatusPageIO.Api;
 
-public interface IStatusPageIoClient : IDisposable
+public interface IStatusPageIoClient
 {
     #region Summary
 

--- a/src/TTools.StatusPageIO.Api/Models/ComponentModel.cs
+++ b/src/TTools.StatusPageIO.Api/Models/ComponentModel.cs
@@ -1,0 +1,30 @@
+namespace TTools.StatusPageIO.Api.Models;
+
+public class ComponentModel
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonPropertyName("updated_at")]
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    // TODO: enum
+    [JsonPropertyName("status")]
+    public string Status { get; set; }
+
+    [JsonPropertyName("position")]
+    public int Position { get; set; }
+
+    [JsonPropertyName("page_id")]
+    public string PageId { get; set; }
+
+}

--- a/src/TTools.StatusPageIO.Api/Models/ComponentModel.cs
+++ b/src/TTools.StatusPageIO.Api/Models/ComponentModel.cs
@@ -3,10 +3,10 @@ namespace TTools.StatusPageIO.Api.Models;
 public class ComponentModel
 {
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonPropertyName("description")]
-    public string Description { get; set; }
+    public string Description { get; set; } = null!;
 
     [JsonPropertyName("created_at")]
     public DateTimeOffset CreatedAt { get; set; }
@@ -15,16 +15,16 @@ public class ComponentModel
     public DateTimeOffset UpdatedAt { get; set; }
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     // TODO: enum
     [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public string Status { get; set; } = null!;
 
     [JsonPropertyName("position")]
     public int Position { get; set; }
 
     [JsonPropertyName("page_id")]
-    public string PageId { get; set; }
+    public string PageId { get; set; } = null!;
 
 }

--- a/src/TTools.StatusPageIO.Api/Models/ComponentModel.cs
+++ b/src/TTools.StatusPageIO.Api/Models/ComponentModel.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models;
 
-public class ComponentModel
+public record ComponentModel
 {
     [JsonPropertyName("id")]
     public string Id { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/Incident.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Incident.cs
@@ -3,7 +3,7 @@ namespace TTools.StatusPageIO.Api.Models;
 public class Incident
 {
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonPropertyName("created_at")]
     public DateTimeOffset CreatedAt { get; set; }
@@ -19,21 +19,21 @@ public class Incident
 
     // TODO: enum??
     [JsonPropertyName("impact")]
-    public string Impact { get; set; }
+    public string Impact { get; set; } = null!;
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("page_id")]
-    public string PageId { get; set; }
+    public string PageId { get; set; } = null!;
 
     [JsonPropertyName("shortlink")]
-    public Uri Shortlink { get; set; }
+    public Uri Shortlink { get; set; } = null!;
 
     // TODO: enum
     [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public string Status { get; set; } = null!;
 
     [JsonPropertyName("incident_updates")]
-    public IList<IncidentUpdate> Updates { get; set; }
+    public IList<IncidentUpdate> Updates { get; set; } = null!;
 }

--- a/src/TTools.StatusPageIO.Api/Models/Incident.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Incident.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models;
 
-public class Incident
+public record Incident
 {
     [JsonPropertyName("id")]
     public string Id { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/Incident.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Incident.cs
@@ -1,0 +1,39 @@
+namespace TTools.StatusPageIO.Api.Models;
+
+public class Incident
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonPropertyName("updated_at")]
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    [JsonPropertyName("monitoring_at")]
+    public DateTimeOffset? MonitoringAt { get; set; }
+
+    [JsonPropertyName("resolved_at")]
+    public DateTimeOffset? ResolvedAt { get; set; }
+
+    // TODO: enum??
+    [JsonPropertyName("impact")]
+    public string Impact { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("page_id")]
+    public string PageId { get; set; }
+
+    [JsonPropertyName("shortlink")]
+    public Uri Shortlink { get; set; }
+
+    // TODO: enum
+    [JsonPropertyName("status")]
+    public string Status { get; set; }
+
+    [JsonPropertyName("incident_updates")]
+    public IList<IncidentUpdate> Updates { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/IncidentUpdate.cs
+++ b/src/TTools.StatusPageIO.Api/Models/IncidentUpdate.cs
@@ -1,0 +1,25 @@
+namespace TTools.StatusPageIO.Api.Models;
+
+public class IncidentUpdate
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonPropertyName("updated_at")]
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    [JsonPropertyName("display_at")]
+    public DateTimeOffset DisplayAt { get; set; }
+
+    [JsonPropertyName("body")]
+    public string Body { get; set; }
+
+    [JsonPropertyName("incident_id")]
+    public string IncidentId { get; set; }
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/IncidentUpdate.cs
+++ b/src/TTools.StatusPageIO.Api/Models/IncidentUpdate.cs
@@ -3,7 +3,7 @@ namespace TTools.StatusPageIO.Api.Models;
 public class IncidentUpdate
 {
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonPropertyName("created_at")]
     public DateTimeOffset CreatedAt { get; set; }
@@ -15,11 +15,11 @@ public class IncidentUpdate
     public DateTimeOffset DisplayAt { get; set; }
 
     [JsonPropertyName("body")]
-    public string Body { get; set; }
+    public string Body { get; set; } = null!;
 
     [JsonPropertyName("incident_id")]
-    public string IncidentId { get; set; }
+    public string IncidentId { get; set; } = null!;
 
     [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public string Status { get; set; } = null!;
 }

--- a/src/TTools.StatusPageIO.Api/Models/IncidentUpdate.cs
+++ b/src/TTools.StatusPageIO.Api/Models/IncidentUpdate.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models;
 
-public class IncidentUpdate
+public record IncidentUpdate
 {
     [JsonPropertyName("id")]
     public string Id { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/PageInfo.cs
+++ b/src/TTools.StatusPageIO.Api/Models/PageInfo.cs
@@ -3,13 +3,13 @@ namespace TTools.StatusPageIO.Api.Models;
 public class PageInfo
 {
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("url")]
-    public Uri Url { get; set; }
+    public Uri Url { get; set; } = null!;
 
     [JsonPropertyName("updated_at")]
     public DateTimeOffset UpdatedAt { get; set; }

--- a/src/TTools.StatusPageIO.Api/Models/PageInfo.cs
+++ b/src/TTools.StatusPageIO.Api/Models/PageInfo.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models;
 
-public class PageInfo
+public record PageInfo
 {
     [JsonPropertyName("id")]
     public string Id { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/PageInfo.cs
+++ b/src/TTools.StatusPageIO.Api/Models/PageInfo.cs
@@ -1,0 +1,16 @@
+namespace TTools.StatusPageIO.Api.Models;
+
+public class PageInfo
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("url")]
+    public Uri Url { get; set; }
+
+    [JsonPropertyName("updated_at")]
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/Response/BaseResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/BaseResponse.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models.Response;
 
-public class BaseResponse
+public record BaseResponse
 {
     [JsonPropertyName("page")]
     public PageInfo Page { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/Response/BaseResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/BaseResponse.cs
@@ -3,5 +3,5 @@ namespace TTools.StatusPageIO.Api.Models.Response;
 public class BaseResponse
 {
     [JsonPropertyName("page")]
-    public PageInfo Page { get; set; }
+    public PageInfo Page { get; set; } = null!;
 }

--- a/src/TTools.StatusPageIO.Api/Models/Response/BaseResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/BaseResponse.cs
@@ -1,0 +1,7 @@
+namespace TTools.StatusPageIO.Api.Models.Response;
+
+public class BaseResponse
+{
+    [JsonPropertyName("page")]
+    public PageInfo Page { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/Response/ComponentsResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/ComponentsResponse.cs
@@ -3,5 +3,5 @@ namespace TTools.StatusPageIO.Api.Models.Response;
 public class ComponentsResponse : BaseResponse
 {
     [JsonPropertyName("components")]
-    public IList<ComponentModel> Components { get; set; }
+    public IList<ComponentModel> Components { get; set; } = null!;
 }

--- a/src/TTools.StatusPageIO.Api/Models/Response/ComponentsResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/ComponentsResponse.cs
@@ -1,0 +1,7 @@
+namespace TTools.StatusPageIO.Api.Models.Response;
+
+public class ComponentsResponse : BaseResponse
+{
+    [JsonPropertyName("components")]
+    public IList<ComponentModel> Components { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/Response/ComponentsResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/ComponentsResponse.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models.Response;
 
-public class ComponentsResponse : BaseResponse
+public record ComponentsResponse : BaseResponse
 {
     [JsonPropertyName("components")]
     public IList<ComponentModel> Components { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/Response/IncidentsResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/IncidentsResponse.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models.Response;
 
-public class IncidentsResponse : BaseResponse
+public record IncidentsResponse : BaseResponse
 {
     [JsonPropertyName("incidents")]
     public IList<Incident> Incidents { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/Response/IncidentsResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/IncidentsResponse.cs
@@ -1,0 +1,7 @@
+namespace TTools.StatusPageIO.Api.Models.Response;
+
+public class IncidentsResponse : BaseResponse
+{
+    [JsonPropertyName("incidents")]
+    public IList<Incident> Incidents { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/Response/IncidentsResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/IncidentsResponse.cs
@@ -3,5 +3,5 @@ namespace TTools.StatusPageIO.Api.Models.Response;
 public class IncidentsResponse : BaseResponse
 {
     [JsonPropertyName("incidents")]
-    public IList<Incident> Incidents { get; set; }
+    public IList<Incident> Incidents { get; set; } = null!;
 }

--- a/src/TTools.StatusPageIO.Api/Models/Response/ScheduledMaintenancesResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/ScheduledMaintenancesResponse.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models.Response;
 
-public class ScheduledMaintenancesResponse : BaseResponse
+public record ScheduledMaintenancesResponse : BaseResponse
 {
     [JsonPropertyName("scheduled_maintenances")]
     public IList<ScheduledMaintenance> ScheduledMaintenances { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/Response/ScheduledMaintenancesResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/ScheduledMaintenancesResponse.cs
@@ -3,5 +3,5 @@ namespace TTools.StatusPageIO.Api.Models.Response;
 public class ScheduledMaintenancesResponse : BaseResponse
 {
     [JsonPropertyName("scheduled_maintenances")]
-    public IList<ScheduledMaintenance> ScheduledMaintenances { get; set; }
+    public IList<ScheduledMaintenance> ScheduledMaintenances { get; set; } = null!;
 }

--- a/src/TTools.StatusPageIO.Api/Models/Response/ScheduledMaintenancesResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/ScheduledMaintenancesResponse.cs
@@ -1,0 +1,7 @@
+namespace TTools.StatusPageIO.Api.Models.Response;
+
+public class ScheduledMaintenancesResponse : BaseResponse
+{
+    [JsonPropertyName("scheduled_maintenances")]
+    public IList<ScheduledMaintenance> ScheduledMaintenances { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/Response/StatusResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/StatusResponse.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models.Response;
 
-public class StatusResponse : BaseResponse
+public record StatusResponse : BaseResponse
 {
     [JsonPropertyName("status")]
     public Status Status { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/Response/StatusResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/StatusResponse.cs
@@ -3,5 +3,5 @@ namespace TTools.StatusPageIO.Api.Models.Response;
 public class StatusResponse : BaseResponse
 {
     [JsonPropertyName("status")]
-    public Status Status { get; set; }
+    public Status Status { get; set; } = null!;
 }

--- a/src/TTools.StatusPageIO.Api/Models/Response/StatusResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/StatusResponse.cs
@@ -1,0 +1,7 @@
+namespace TTools.StatusPageIO.Api.Models.Response;
+
+public class StatusResponse : BaseResponse
+{
+    [JsonPropertyName("status")]
+    public Status Status { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/Response/SummaryResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/SummaryResponse.cs
@@ -3,14 +3,14 @@ namespace TTools.StatusPageIO.Api.Models.Response;
 public class SummaryResponse : BaseResponse
 {
     [JsonPropertyName("status")]
-    public Status Status { get; set; }
+    public Status Status { get; set; } = null!;
 
     [JsonPropertyName("components")]
-    public IList<ComponentModel> Components { get; set; }
+    public IList<ComponentModel> Components { get; set; } = null!;
 
     [JsonPropertyName("incidents")]
-    public IList<Incident> Incidents { get; set; }
+    public IList<Incident> Incidents { get; set; } = null!;
 
     [JsonPropertyName("scheduled_maintenances")]
-    public IList<ScheduledMaintenance> ScheduledMaintenances { get; set; }
+    public IList<ScheduledMaintenance> ScheduledMaintenances { get; set; } = null!;
 }

--- a/src/TTools.StatusPageIO.Api/Models/Response/SummaryResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/SummaryResponse.cs
@@ -1,0 +1,16 @@
+namespace TTools.StatusPageIO.Api.Models.Response;
+
+public class SummaryResponse : BaseResponse
+{
+    [JsonPropertyName("status")]
+    public Status Status { get; set; }
+
+    [JsonPropertyName("components")]
+    public IList<ComponentModel> Components { get; set; }
+
+    [JsonPropertyName("incidents")]
+    public IList<Incident> Incidents { get; set; }
+
+    [JsonPropertyName("scheduled_maintenances")]
+    public IList<ScheduledMaintenance> ScheduledMaintenances { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/Response/SummaryResponse.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Response/SummaryResponse.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models.Response;
 
-public class SummaryResponse : BaseResponse
+public record SummaryResponse : BaseResponse
 {
     [JsonPropertyName("status")]
     public Status Status { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/ScheduledMaintenance.cs
+++ b/src/TTools.StatusPageIO.Api/Models/ScheduledMaintenance.cs
@@ -1,0 +1,10 @@
+namespace TTools.StatusPageIO.Api.Models;
+
+public class ScheduledMaintenance : Incident
+{
+    [JsonPropertyName("scheduled_for")]
+    public DateTimeOffset ScheduledFor { get; set; }
+
+    [JsonPropertyName("scheduled_until")]
+    public DateTimeOffset ScheduledUntil { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/Models/ScheduledMaintenance.cs
+++ b/src/TTools.StatusPageIO.Api/Models/ScheduledMaintenance.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models;
 
-public class ScheduledMaintenance : Incident
+public record ScheduledMaintenance : Incident
 {
     [JsonPropertyName("scheduled_for")]
     public DateTimeOffset ScheduledFor { get; set; }

--- a/src/TTools.StatusPageIO.Api/Models/Status.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Status.cs
@@ -3,10 +3,10 @@ namespace TTools.StatusPageIO.Api.Models;
 public class Status
 {
     [JsonPropertyName("description")]
-    public string Description { get; set; }
+    public string Description { get; set; } = null!;
 
     // TODO: enum
     // none, minor, major, or critical
     [JsonPropertyName("indicator")]
-    public string Indicator { get; set; }
+    public string Indicator { get; set; } = null!;
 }

--- a/src/TTools.StatusPageIO.Api/Models/Status.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Status.cs
@@ -1,6 +1,6 @@
 namespace TTools.StatusPageIO.Api.Models;
 
-public class Status
+public record Status
 {
     [JsonPropertyName("description")]
     public string Description { get; set; } = null!;

--- a/src/TTools.StatusPageIO.Api/Models/Status.cs
+++ b/src/TTools.StatusPageIO.Api/Models/Status.cs
@@ -1,0 +1,12 @@
+namespace TTools.StatusPageIO.Api.Models;
+
+public class Status
+{
+    [JsonPropertyName("description")]
+    public string Description { get; set; }
+
+    // TODO: enum
+    // none, minor, major, or critical
+    [JsonPropertyName("indicator")]
+    public string Indicator { get; set; }
+}

--- a/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
+++ b/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using TTools.StatusPageIO.Api.Models.Response;
 
 namespace TTools.StatusPageIO.Api;
@@ -14,10 +14,17 @@ public class StatusPageIoClient : IStatusPageIoClient
     private const string ActiveMaintenancesEndpoint = "/api/v2/scheduled-maintenances/active.json";
     private const string AllMaintenancesEndpoint = "/api/v2/scheduled-maintenances.json";
 
+    private readonly bool _isManagedHttpClient = true;
     private readonly HttpClient _httpClient;
 
     // ReSharper disable once RedundantDefaultMemberInitializer
     private bool _disposing = false;
+
+    public StatusPageIoClient()
+    {
+        _isManagedHttpClient = false;
+        _httpClient = new HttpClient();
+    }
 
     // TODO: Action to configure
     public StatusPageIoClient(HttpClient httpClient)
@@ -111,7 +118,7 @@ public class StatusPageIoClient : IStatusPageIoClient
     public void Dispose()
     {
         // Should let the underlying DI container dispose of the HttpMessageHandler if we didn't create it
-        if (_disposing)
+        if (_disposing || _isManagedHttpClient)
             return;
 
         _disposing = true;

--- a/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
+++ b/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using TTools.StatusPageIO.Api.Models.Response;
 
 namespace TTools.StatusPageIO.Api;
@@ -104,4 +104,6 @@ public class StatusPageIoClient : IStatusPageIoClient
 
         return deserializedResponse;
     }
+
+    public void Dispose() => _httpClient.Dispose();
 }

--- a/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
+++ b/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
@@ -14,7 +14,6 @@ public class StatusPageIoClient : IStatusPageIoClient
     private const string ActiveMaintenancesEndpoint = "/api/v2/scheduled-maintenances/active.json";
     private const string AllMaintenancesEndpoint = "/api/v2/scheduled-maintenances.json";
 
-    // TODO: IHttpClientFactory
     private readonly HttpClient _httpClient;
 
     // TODO: Action to configure

--- a/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
+++ b/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
@@ -1,0 +1,110 @@
+﻿using System.Text.Json;
+using TTools.StatusPageIO.Api.Models.Response;
+
+namespace TTools.StatusPageIO.Api;
+
+public class StatusPageIoClient : IStatusPageIoClient
+{
+    private const string SummaryEndpoint = "/api/v2/summary.json";
+    private const string StatusEndpoint = "/api/v2/status.json";
+    private const string ComponentsEndpoint = "/api/v2/components.json";
+    private const string UnresolvedIncidentsEndpoint = "/api/v2/incidents/unresolved.json";
+    private const string AllIncidentsEndpoint = "/api/v2/incidents.json";
+    private const string UpcomingMaintenancesEndpoint = "/api/v2/scheduled-maintenances/upcoming.json";
+    private const string ActiveMaintenancesEndpoint = "/api/v2/scheduled-maintenances/active.json";
+    private const string AllMaintenancesEndpoint = "/api/v2/scheduled-maintenances.json";
+
+    // TODO: IHttpClientFactory
+    private readonly HttpClient _httpClient;
+
+    // TODO: Action to configure
+    public StatusPageIoClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    /// <inheritdoc />
+    public Task<SummaryResponse?> GetSummaryAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            throw new TaskCanceledException("The HttpClient task was prematurely cancelled");
+
+        return RequestAndDeserializeEndpointAsync<SummaryResponse>(SummaryEndpoint, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<StatusResponse?> GetStatusAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            throw new TaskCanceledException("The HttpClient task was prematurely cancelled");
+
+        return RequestAndDeserializeEndpointAsync<StatusResponse>(StatusEndpoint, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<ComponentsResponse?> GetComponentsAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            throw new TaskCanceledException("The HttpClient task was prematurely cancelled");
+
+        return RequestAndDeserializeEndpointAsync<ComponentsResponse>(ComponentsEndpoint, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<IncidentsResponse?> GetUnresolvedIncidentsAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            throw new TaskCanceledException("The HttpClient task was prematurely cancelled");
+
+        return RequestAndDeserializeEndpointAsync<IncidentsResponse>(UnresolvedIncidentsEndpoint, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<IncidentsResponse?> GetAllIncidentsAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            throw new TaskCanceledException("The HttpClient task was prematurely cancelled");
+
+        return RequestAndDeserializeEndpointAsync<IncidentsResponse>(AllIncidentsEndpoint, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<ScheduledMaintenancesResponse?> GetUpcomingMaintenanceAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            throw new TaskCanceledException("The HttpClient task was prematurely cancelled");
+
+        return RequestAndDeserializeEndpointAsync<ScheduledMaintenancesResponse>(UpcomingMaintenancesEndpoint, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<ScheduledMaintenancesResponse?> GetActiveMaintenanceAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            throw new TaskCanceledException("The HttpClient task was prematurely cancelled");
+
+        return RequestAndDeserializeEndpointAsync<ScheduledMaintenancesResponse>(ActiveMaintenancesEndpoint, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<ScheduledMaintenancesResponse?> GetAllMaintenanceAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            throw new TaskCanceledException("The HttpClient task was prematurely cancelled");
+
+        return RequestAndDeserializeEndpointAsync<ScheduledMaintenancesResponse>(AllMaintenancesEndpoint, cancellationToken);
+    }
+
+    // ReSharper disable once InconsistentNaming
+    private async Task<TResult?> RequestAndDeserializeEndpointAsync<TResult>(string relativePath,
+        CancellationToken cancellationToken)
+    {
+        Stream? responseStream = await _httpClient.GetStreamAsync(relativePath);
+        var deserializedResponse = await JsonSerializer.DeserializeAsync<TResult>(
+            responseStream, cancellationToken: cancellationToken);
+
+        return deserializedResponse;
+    }
+
+    public void Dispose() => _httpClient.Dispose();
+}

--- a/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
+++ b/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using TTools.StatusPageIO.Api.Models.Response;
 
 namespace TTools.StatusPageIO.Api;
@@ -105,6 +105,4 @@ public class StatusPageIoClient : IStatusPageIoClient
 
         return deserializedResponse;
     }
-
-    public void Dispose() => _httpClient.Dispose();
 }

--- a/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
+++ b/src/TTools.StatusPageIO.Api/StatusPageIoClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using TTools.StatusPageIO.Api.Models.Response;
 
 namespace TTools.StatusPageIO.Api;
@@ -15,6 +15,9 @@ public class StatusPageIoClient : IStatusPageIoClient
     private const string AllMaintenancesEndpoint = "/api/v2/scheduled-maintenances.json";
 
     private readonly HttpClient _httpClient;
+
+    // ReSharper disable once RedundantDefaultMemberInitializer
+    private bool _disposing = false;
 
     // TODO: Action to configure
     public StatusPageIoClient(HttpClient httpClient)
@@ -105,5 +108,13 @@ public class StatusPageIoClient : IStatusPageIoClient
         return deserializedResponse;
     }
 
-    public void Dispose() => _httpClient.Dispose();
+    public void Dispose()
+    {
+        // Should let the underlying DI container dispose of the HttpMessageHandler if we didn't create it
+        if (_disposing)
+            return;
+
+        _disposing = true;
+        _httpClient.Dispose();
+    }
 }

--- a/src/TTools.StatusPageIO.Api/StatusPageIoClientConfiguration.cs
+++ b/src/TTools.StatusPageIO.Api/StatusPageIoClientConfiguration.cs
@@ -1,0 +1,10 @@
+namespace TTools.StatusPageIO.Api;
+
+public class StatusPageIoClientConfiguration
+{
+    /// <summary>
+    /// The base URI of the status page
+    /// e.g. https://discordstatus.com or https://www.githubstatus.com
+    /// </summary>
+    public Uri StatusPageBaseUri { get; set; } = null!;
+}

--- a/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
+++ b/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>10</LangVersion>
+    </PropertyGroup>
+
+</Project>

--- a/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
+++ b/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
@@ -8,4 +8,27 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <PackageId>TTools.StatusPageIO.Api</PackageId>
+        <Description>API to retrieve status information from public statuspage.io API endpoints</Description>
+        <Authors>TTools</Authors>
+
+        <Version>1.0.0</Version>
+        <PackageVersion>1.0.0</PackageVersion>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+
+        <Copyright>TTools 2022</Copyright>
+        <PackageProjectUrl>https://github.com/ttools-dev/TTools.StatusPageIO.Api</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/ttools-dev/TTools.StatusPageIO.Api</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>statuspage;statuspage.io;httpclient</PackageTags>
+
+        <PackageReleaseNotes>
+            Initial release, supporting a single registered instance of a client per DI container
+        </PackageReleaseNotes>
+
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageLicenseUrl>https://github.com/ttools-dev/TTools.StatusPageIO.Api/tree/main/LICENSE</PackageLicenseUrl>
+    </PropertyGroup>
+
 </Project>

--- a/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
+++ b/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
@@ -31,4 +31,9 @@
         <PackageLicenseUrl>https://github.com/ttools-dev/TTools.StatusPageIO.Api/tree/main/LICENSE</PackageLicenseUrl>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+      <PackageReference Include="System.Text.Json" Version="6.0.5" />
+    </ItemGroup>
+
 </Project>

--- a/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
+++ b/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     </PropertyGroup>
 
 </Project>

--- a/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
+++ b/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
@@ -32,6 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
       <PackageReference Include="System.Text.Json" Version="6.0.5" />

--- a/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
+++ b/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
@@ -21,7 +21,7 @@
         <PackageProjectUrl>https://github.com/ttools-dev/TTools.StatusPageIO.Api</PackageProjectUrl>
         <RepositoryUrl>https://github.com/ttools-dev/TTools.StatusPageIO.Api</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageTags>statuspage;statuspage.io;httpclient</PackageTags>
+        <PackageTags>statuspage;statuspageio;statuspage.io;httpclient</PackageTags>
 
         <PackageReleaseNotes>
             Initial release, supporting a single registered instance of a client per DI container

--- a/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
+++ b/src/TTools.StatusPageIO.Api/TTools.StatusPageIO.Api.csproj
@@ -32,6 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
       <PackageReference Include="System.Text.Json" Version="6.0.5" />
     </ItemGroup>


### PR DESCRIPTION
This PR aims to release basic read support for statuspage.io's public JSON-based "API". Currently, only one instance of the API client can be registered with a DI container - limiting usage to a single org's status page. 